### PR TITLE
Switch to l3.small by default

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -21,7 +21,7 @@ nodeGroupDefaults:
   # Indicates if the node group should be autoscaled
   autoscale: false
   # The flavor to use for machines in the node group
-  machineFlavor: l3.nano
+  machineFlavor: l3.small
 
   healthCheck:
     # Indicates if the machine health check should be enabled


### PR DESCRIPTION
The disk space on an l3.nano is too small, and quickly runs into disk pressure causing pods to become evicted